### PR TITLE
Fixed icon generation for AdaptiveIconDrawable

### DIFF
--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.graphics.Canvas
 import android.os.Build
 import androidx.annotation.NonNull
 import androidx.core.graphics.BitmapCompat
@@ -1585,9 +1586,17 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
         }
         result.success(
             drawable.run {
-                (this as? BitmapDrawable)?.let {
+                (this as? Drawable)?.let {
+                    val bitmap = Bitmap.createBitmap(
+                        it.intrinsicWidth,
+                        it.intrinsicHeight,
+                        Bitmap.Config.ARGB_8888
+                    )
+                    val canvas = Canvas(bitmap)
+                    it.setBounds(0, 0, canvas.width, canvas.height)
+                    it.draw(canvas)
                     ByteArrayOutputStream().use { o ->
-                        it.bitmap.compress(
+                        bitmap.compress(
                             nFormat, quality ?: 100, o
                         )
                         o.toByteArray()

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0"
+    version: "0.5.2+1"
   archive:
     dependency: transitive
     description:


### PR DESCRIPTION
[Android 7.1](https://developer.android.com/about/versions/nougat/android-7.1#circular-icons) introduced the use of [AdaptiveIconDrawable](https://developer.android.com/reference/android/graphics/drawable/AdaptiveIconDrawable). The previous implementation of icon generation in this package did not consider them, so apps with adaptive icons were left without icons at all.

This pull request fixes the problem and implements generating icons from Drawables. Screenshots below present the changes in the example project:

![api23](https://user-images.githubusercontent.com/79166768/227704346-158456e6-9ad1-44fa-9c68-35938dba14e2.png)
API23: No changes on Android 6.0 (before introducing AdaptiveIconDrawable in Android).


![api26](https://user-images.githubusercontent.com/79166768/227704424-495d9ce9-6e81-4045-a1da-16bc3ee0c6ff.png)
API26: AdaptiveIconDrawable now working on Android 8.0

![api30](https://user-images.githubusercontent.com/79166768/227704487-0e0a3a77-3b90-4bc0-90df-27e3e95cb827.png)
API30: AdaptiveIconDrawable working on Android 11

![api33](https://user-images.githubusercontent.com/79166768/227704512-e8170b33-9003-4ebe-83ce-0efc2b1ec6e5.png)
API33: AdaptiveIconDrawable working on Android 13