### PR TITLE
Allow Some Functionality in Background Isolates + Fix Dart SDK Incompatibility + Add `versionCode` to `PackageInfo` + Add `getApplicationLabel`

### DIFF
--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -49,7 +49,9 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "android_package_manager")
         channel.setMethodCallHandler(this)
-        context = flutterPluginBinding.applicationContext
+        if (packageManager == null) {
+            packageManager = flutterPluginBinding.applicationContext.packageManager
+        }
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -219,7 +221,6 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        packageManager = context.packageManager
         activityContext = binding.activity
         if (activityContext != null) {
             packageManager = activityContext.PackageManager

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -223,7 +223,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityContext = binding.activity
         if (activityContext != null) {
-            packageManager = activityContext.PackageManager
+            packageManager = binding.activity.packageManager
         }
     }
 

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -33,6 +33,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
 
     private lateinit var packageManager: PackageManager
     private lateinit var activityContext: Context
+    private lateinit var context: Context
     
     companion object {
         @JvmStatic
@@ -48,6 +49,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "android_package_manager")
         channel.setMethodCallHandler(this)
+        context = flutterPluginBinding.applicationContext
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -217,7 +219,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        packageManager = binding.activity.packageManager
+        packageManager = context.packageManager
         activityContext = binding.activity
     }
 

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -78,10 +78,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
             "getApplicationBanner" -> getApplicationBanner(call, result)
             "getApplicationEnabledSetting" -> getApplicationEnabledSetting(call, result)
             "getApplicationIcon" -> getApplicationIcon(call, result)
-            "getApplicationLabel" -> {
-                // TODO: Research for [ActivityInfo] required
-                result.success(null)
-            }
+            "getApplicationLabel" -> getApplicationLabel(call, result)
             "getBackgroundPermissionOptionLabel" -> getBackgroundPermissionOptionLabel(result)
             "getChangedPackages" -> getChangedPackages(call, result)
             "getComponentEnabledSetting" -> getComponentEnabledSetting(call, result)
@@ -612,6 +609,18 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
                     call.argument<Int?>("quality"),
                     call.argument<Int?>("format") ?: 0,
                     result
+                )
+            } catch (ex: PackageManager.NameNotFoundException) {
+                result.error(ex.javaClass.name, ex.message, null)
+            }
+        }
+    }
+
+    private fun getApplicationLabel(call: MethodCall, result: Result) {
+        providePackageName(call, result)?.let {
+            try {
+                result.success(
+                    packageManager.getApplicationLabel(packageManager.getApplicationInfo(it, 0))
                 )
             } catch (ex: PackageManager.NameNotFoundException) {
                 result.error(ex.javaClass.name, ex.message, null)

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -221,6 +221,9 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         packageManager = context.packageManager
         activityContext = binding.activity
+        if (activityContext != null) {
+            packageManager = activityContext.PackageManager
+        }
     }
 
     override fun onDetachedFromActivityForConfigChanges() {}

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/AndroidPackageManagerPlugin.kt
@@ -49,9 +49,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "android_package_manager")
         channel.setMethodCallHandler(this)
-        if (packageManager == null) {
-            packageManager = flutterPluginBinding.applicationContext.packageManager
-        }
+        packageManager = flutterPluginBinding.applicationContext.packageManager
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -222,9 +220,7 @@ class AndroidPackageManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAwa
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activityContext = binding.activity
-        if (activityContext != null) {
-            packageManager = binding.activity.packageManager
-        }
+        packageManager = binding.activity.packageManager
     }
 
     override fun onDetachedFromActivityForConfigChanges() {}

--- a/android/src/main/kotlin/lab/neruno/android_package_manager/MapUtils.kt
+++ b/android/src/main/kotlin/lab/neruno/android_package_manager/MapUtils.kt
@@ -250,6 +250,7 @@ fun PackageInfo.toMap(): Map<String, Any?> {
         "packageName" to packageName,
         "splitNames" to splitNames?.toList<String>(),
         "versionName" to versionName,
+        "versionCode" to versionCode,
         "sharedUserId" to sharedUserId,
         "sharedUserLabel" to sharedUserLabel,
         "applicationInfo" to applicationInfo?.toMap(),

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,8 +91,12 @@ class _MainPageState extends State<MainPage> {
                     },
                   ),
                 ),
-                title: Text(
-                  info.applicationInfo?.name ?? "No Name",
+                title: FutureBuilder<String?>(
+                  future: AndroidPackageManager()
+                      .getApplicationLabel(packageName: info.packageName!),
+                  builder: (context, snapshot) => Text(
+                    snapshot.data ?? "No Name",
+                  ),
                 ),
                 subtitle: Text('${info.packageName} (${info.versionCode})'),
               ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,6 @@ class MyApp extends StatelessWidget {
 }
 
 class MainPage extends StatefulWidget {
-
   const MainPage({Key? key}) : super(key: key);
 
   @override
@@ -32,30 +31,34 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-
   @override
   void initState() {
     super.initState();
-    AndroidPackageManager().getInstalledApplications().then(
-      (value) => setState(
-        () => _applicationInfoList = value,
-      ),
-    );
+    AndroidPackageManager().getInstalledPackages().then(
+          (value) => setState(
+            () => _applicationInfoList = value,
+          ),
+        );
   }
 
   @override
   Widget build(BuildContext context) {
-
     final appInfo = _applicationInfoList;
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Android Package Manager Demo",),
+        title: const Text(
+          "Android Package Manager Demo",
+        ),
       ),
       body: ListView.builder(
         padding: const EdgeInsets.symmetric(
-          horizontal: 24.0, vertical: 32.0,
+          horizontal: 24.0,
+          vertical: 32.0,
         ),
-        itemBuilder: (_, index,) {
+        itemBuilder: (
+          _,
+          index,
+        ) {
           final info = appInfo![index];
           return Padding(
             padding: const EdgeInsets.symmetric(
@@ -66,8 +69,11 @@ class _MainPageState extends State<MainPage> {
                 leading: SizedBox.square(
                   dimension: 48.0,
                   child: FutureBuilder<Uint8List?>(
-                    future: info.getAppIcon(),
-                    builder: (context, snapshot,) {
+                    future: info.applicationInfo?.getAppIcon(),
+                    builder: (
+                      context,
+                      snapshot,
+                    ) {
                       if (snapshot.hasData) {
                         final iconBytes = snapshot.data!;
                         return Image.memory(
@@ -76,14 +82,19 @@ class _MainPageState extends State<MainPage> {
                         );
                       }
                       if (snapshot.hasError) {
-                        return const Icon(Icons.error, color: Colors.red,);
+                        return const Icon(
+                          Icons.error,
+                          color: Colors.red,
+                        );
                       }
                       return const SizedBox.shrink();
                     },
                   ),
                 ),
-                title: Text(info.name ?? "No Name",),
-                subtitle: Text(info.packageName ?? "-",),
+                title: Text(
+                  info.applicationInfo?.name ?? "No Name",
+                ),
+                subtitle: Text('${info.packageName} (${info.versionCode})'),
               ),
             ),
           );
@@ -93,5 +104,5 @@ class _MainPageState extends State<MainPage> {
     );
   }
 
-  List<ApplicationInfo>? _applicationInfoList;
+  List<PackageInfo>? _applicationInfoList;
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,10 +84,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -110,10 +110,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -146,10 +146,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
@@ -295,18 +295,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
+      sha256: f2add6fa510d3ae152903412227bda57d0d5a8da61d2c39c1fb022c9429a41c0
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.4"
+    version: "5.0.6"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      sha256: e4506d60b7244251bc59df15656a3093501c37fb5af02105a944d73eb95be4c9
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -8,22 +8,14 @@ packages:
       relative: true
     source: path
     version: "0.5.4"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      sha256: "80e5141fafcb3361653ce308776cfd7d45e6e9fbb429e14eec571382c0c5fecb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -36,10 +28,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -52,18 +44,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -154,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -170,10 +154,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -186,18 +170,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   platform:
     dependency: transitive
     description:
@@ -279,18 +263,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -303,18 +279,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.3.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   win32:
     dependency: transitive
     description:
@@ -332,5 +308,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=2.19.3 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/android_package_manager.dart
+++ b/lib/android_package_manager.dart
@@ -15,54 +15,69 @@ export 'src/entities/enums.dart';
 part 'src/android_package_manager_impl.dart';
 
 abstract class AndroidPackageManager {
-
   AndroidPackageManager._();
 
   static final AndroidPackageManager _pm = AndroidPackageManagerImpl();
 
   factory AndroidPackageManager() {
     if (!Platform.isAndroid) {
-      throw StateError("Can only be runned on Android devices",);
+      throw StateError(
+        "Can only be runned on Android devices",
+      );
     }
     return _pm;
   }
 
   Future<bool> canPackageQuery({
-    required String sourcePackageName, required String targetPackageName,
-  }) => throw UnimplementedError();
+    required String sourcePackageName,
+    required String targetPackageName,
+  }) =>
+      throw UnimplementedError();
 
   Future<List<String>?> canonicalToCurrentPackageNames({
     required List<String> packageNames,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<CheckPermissionStatus?> checkPermission({
     required String packageName,
     required String permName,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<SignatureCheckResult> checkSignatures({
-    required String packageName1, required String packageName2,
-  }) => throw UnimplementedError();
+    required String packageName1,
+    required String packageName2,
+  }) =>
+      throw UnimplementedError();
 
   Future<List<String>?> currentToCanonicalPackageNames({
     required List<String> packageNames,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<Uint8List?> getActivityDrawableResource({
     required ComponentName componentName,
     required ActivityResourceType type,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<List<PermissionGroupInfo>?> getAllPermissionGroups({
     PermissionGroupInfoFlags? flags,
   });
 
-  Future<bool?> getApplicationEnabledSetting({required String packageName,});
+  Future<bool?> getApplicationEnabledSetting({
+    required String packageName,
+  });
 
   Future<Uint8List?> getApplicationIcon({
     required String packageName,
     BitmapCompressFormat format = BitmapCompressFormat.png,
     int quality = 100,
+  });
+
+  Future<String?> getApplicationLabel({
+    required String packageName,
   });
 
   Future<Uint8List?> getActivityIcon({
@@ -77,109 +92,172 @@ abstract class AndroidPackageManager {
     int quality = 100,
   });
 
-  Future<bool?> getComponentEnabledSetting({required String packageName,});
+  Future<bool?> getComponentEnabledSetting({
+    required String packageName,
+  });
 
   Future<Uint8List?> getDefaultActivityIcon();
 
   /// Available for SDK Int >= 30 (Android R)
-  Future<InstallSourceInfo?> getInstallSourceInfo({required String packageName,});
+  Future<InstallSourceInfo?> getInstallSourceInfo({
+    required String packageName,
+  });
 
   Future<List<ApplicationInfo>?> getInstalledApplications({
     ApplicationInfoFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<List<PackageInfo>?> getInstalledPackages({
     PackageInfoFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   /// Available for SDK Int < 30 (before Android R)
-  Future<String?> getInstallerPackageName({required String packageName,});
+  Future<String?> getInstallerPackageName({
+    required String packageName,
+  });
 
   Future<InstrumentationInfo?> getInstrumentationInfo({
     required ComponentName componentName,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
-  Future<String?> getNameForUid(int uid,) => throw UnimplementedError();
+  Future<String?> getNameForUid(
+    int uid,
+  ) =>
+      throw UnimplementedError();
 
   Future<PackageInfo?> getPackageArchiveInfo({
     required String archiveFilePath,
     PackageInfoFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<List<int>?> getPackageGids({
     required String packageName,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<PackageInfo?> getPackageInfo({
     required String packageName,
     PackageInfoFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
-  Future<List<String>?> getPackagesForUid(int uid,) => throw UnimplementedError();
+  Future<List<String>?> getPackagesForUid(
+    int uid,
+  ) =>
+      throw UnimplementedError();
 
-  Future<List<PackageInfo>?> getPackagesHoldingPermissions(Set<String> permissions,) => throw UnimplementedError();
+  Future<List<PackageInfo>?> getPackagesHoldingPermissions(
+    Set<String> permissions,
+  ) =>
+      throw UnimplementedError();
 
-  Future<PermissionGroupInfo?> getPermissionGroupInfo(String packageName,) => throw UnimplementedError();
+  Future<PermissionGroupInfo?> getPermissionGroupInfo(
+    String packageName,
+  ) =>
+      throw UnimplementedError();
 
-  Future<PermissionInfo?> getPermissionInfo(String permName,) => throw UnimplementedError();
+  Future<PermissionInfo?> getPermissionInfo(
+    String permName,
+  ) =>
+      throw UnimplementedError();
 
   Future<ProviderInfo?> getProviderInfo({
-    required ComponentName componentName, ComponentInfoFlags? flags,
-  }) => throw UnimplementedError();
+    required ComponentName componentName,
+    ComponentInfoFlags? flags,
+  }) =>
+      throw UnimplementedError();
 
   Future<ActivityInfo?> getReceiverInfo({
-    required ComponentName componentName, ComponentInfoFlags? flags,
-  }) => throw UnimplementedError();
+    required ComponentName componentName,
+    ComponentInfoFlags? flags,
+  }) =>
+      throw UnimplementedError();
 
   Future<ServiceInfo?> getServiceInfo({
-    required ComponentName componentName, ComponentInfoFlags? flags,
-  }) => throw UnimplementedError();
+    required ComponentName componentName,
+    ComponentInfoFlags? flags,
+  }) =>
+      throw UnimplementedError();
 
-  Future<List<FeatureInfo>?> getSystemAvailableFeatures() => throw UnimplementedError();
+  Future<List<FeatureInfo>?> getSystemAvailableFeatures() =>
+      throw UnimplementedError();
 
-  Future<List<String>?> getSystemSharedLibraryNames() => throw UnimplementedError();
+  Future<List<String>?> getSystemSharedLibraryNames() =>
+      throw UnimplementedError();
 
-  Future<bool> hasSystemFeature({required String featureName, int? version,}) => throw UnimplementedError();
+  Future<bool> hasSystemFeature({
+    required String featureName,
+    int? version,
+  }) =>
+      throw UnimplementedError();
 
   Future<bool> isSafeMode() => throw UnimplementedError();
 
-  Future<void> launchLeanback(String packageName,) => throw UnimplementedError();
+  Future<void> launchLeanback(
+    String packageName,
+  ) =>
+      throw UnimplementedError();
 
-  Future<void> openApp(String packageName,) => throw UnimplementedError();
+  Future<void> openApp(
+    String packageName,
+  ) =>
+      throw UnimplementedError();
 
   Future<List<ProviderInfo>?> queryContentProviders({
-    required int uid, String? processName, ComponentInfoFlags? flags,
-  }) => throw UnimplementedError();
+    required int uid,
+    String? processName,
+    ComponentInfoFlags? flags,
+  }) =>
+      throw UnimplementedError();
 
-  Future<List<InstrumentationInfo>?> queryInstrumentation(String targetPackage,) => throw UnimplementedError();
+  Future<List<InstrumentationInfo>?> queryInstrumentation(
+    String targetPackage,
+  ) =>
+      throw UnimplementedError();
 
-  Future<List<PermissionInfo>?> queryPermissionsByGroup(String permissionGroup,) => throw UnimplementedError();
+  Future<List<PermissionInfo>?> queryPermissionsByGroup(
+    String permissionGroup,
+  ) =>
+      throw UnimplementedError();
 
-  Future<void> removePermission(String permName,) => throw UnimplementedError();
+  Future<void> removePermission(
+    String permName,
+  ) =>
+      throw UnimplementedError();
 
   Future<ProviderInfo?> resolveContentProvider({
-    required String authority, ComponentInfoFlags? flags,
-  }) => throw UnimplementedError();
+    required String authority,
+    ComponentInfoFlags? flags,
+  }) =>
+      throw UnimplementedError();
 
   Future<void> setApplicationEnabledSetting({
     required String packageName,
     required ComponentEnabledState newState,
     EnabledFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<void> setComponentEnabledSetting({
     required ComponentName componentName,
     required ComponentEnabledState newState,
     EnabledFlags? flags,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<void> setInstallerPackageName({
     required String targetPackage,
     String? installerPackageName,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 
   Future<void> verifyPendingInstall({
     required int id,
     required VerificationCode verificationCode,
-  }) => throw UnimplementedError();
+  }) =>
+      throw UnimplementedError();
 }

--- a/lib/src/android_package_manager_impl.dart
+++ b/lib/src/android_package_manager_impl.dart
@@ -1,10 +1,11 @@
 part of '../android_package_manager.dart';
 
 class AndroidPackageManagerImpl extends AndroidPackageManager {
+  AndroidPackageManagerImpl() : super._();
 
-  AndroidPackageManagerImpl(): super._();
-
-  static const MethodChannel _channel = MethodChannel('android_package_manager',);
+  static const MethodChannel _channel = MethodChannel(
+    'android_package_manager',
+  );
 
   static const Map<int, CheckPermissionStatus> _checkPermissionResultMap = {
     0: CheckPermissionStatus.granted,
@@ -38,37 +39,55 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   @override
   Future<List<String>?> canonicalToCurrentPackageNames({
     required List<String> packageNames,
-  }) => _channel.invokeListMethod<String>(
-    "canonicalToCurrentPackageNames", {"packageNames": packageNames,},
-  );
+  }) =>
+      _channel.invokeListMethod<String>(
+        "canonicalToCurrentPackageNames",
+        {
+          "packageNames": packageNames,
+        },
+      );
 
   @override
   Future<CheckPermissionStatus?> checkPermission({
-    required String packageName, required String permName,
+    required String packageName,
+    required String permName,
   }) async {
     final checkResult = await _channel.invokeMethod<int>(
-      "checkPermission", {"packageName": packageName, "permName": permName,},
+      "checkPermission",
+      {
+        "packageName": packageName,
+        "permName": permName,
+      },
     );
     return _checkPermissionResultMap[checkResult];
   }
 
   @override
   Future<SignatureCheckResult> checkSignatures({
-    required String packageName1, required String packageName2,
+    required String packageName1,
+    required String packageName2,
   }) async {
     final checkResult = await _channel.invokeMethod<int>(
       "checkSignatures",
-      {"packageName1": packageName1, "packageName2": packageName2,},
+      {
+        "packageName1": packageName1,
+        "packageName2": packageName2,
+      },
     );
-    return _signatureCheckResultMap[checkResult] ?? SignatureCheckResult.unknownPackage;
+    return _signatureCheckResultMap[checkResult] ??
+        SignatureCheckResult.unknownPackage;
   }
 
   @override
   Future<List<String>?> currentToCanonicalPackageNames({
     required List<String> packageNames,
-  }) => _channel.invokeListMethod<String>(
-    "currentToCanonicalPackageNames", {"packageNames": packageNames,},
-  );
+  }) =>
+      _channel.invokeListMethod<String>(
+        "currentToCanonicalPackageNames",
+        {
+          "packageNames": packageNames,
+        },
+      );
 
   @override
   Future<Uint8List?> getActivityDrawableResource({
@@ -81,7 +100,8 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
       ActivityResourceType.logo: "getActivityLogo",
     };
     return _channel.invokeMethod<Uint8List>(
-      availableMethods[type]!, componentName.asMap,
+      availableMethods[type]!,
+      componentName.asMap,
     );
   }
 
@@ -91,73 +111,113 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final permissionGroupsData = await _channel.invokeListMethod(
       "getAllPermissionGroups",
-      {"flags": flags?.flags,},
+      {
+        "flags": flags?.flags,
+      },
     );
-    return permissionGroupsData?.map<PermissionGroupInfo>(
-      (data) => PermissionGroupInfoImpl(
-        Map<String, dynamic>.from(data,),
-      ),
-    ).toList(growable: false,);
+    return permissionGroupsData
+        ?.map<PermissionGroupInfo>(
+          (data) => PermissionGroupInfoImpl(
+            Map<String, dynamic>.from(
+              data,
+            ),
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<bool?> getApplicationEnabledSetting({required String packageName,}) => _channel.invokeMethod<bool>(
-    "getApplicationEnabledSetting",
-    {"packageName": packageName,},
-  );
+  Future<bool?> getApplicationEnabledSetting({
+    required String packageName,
+  }) =>
+      _channel.invokeMethod<bool>(
+        "getApplicationEnabledSetting",
+        {
+          "packageName": packageName,
+        },
+      );
 
   @override
   Future<Uint8List?> getApplicationIcon({
     required String packageName,
     BitmapCompressFormat format = BitmapCompressFormat.png,
     int quality = 100,
-  }) => _channel.invokeMethod<Uint8List>(
-    "getApplicationIcon",
-    {
-      'packageName': packageName,
-      'quality': quality.clamp(1, 100,),
-      'format': format.index,
-    },
-  );
+  }) =>
+      _channel.invokeMethod<Uint8List>(
+        "getApplicationIcon",
+        {
+          'packageName': packageName,
+          'quality': quality.clamp(
+            1,
+            100,
+          ),
+          'format': format.index,
+        },
+      );
+
+  @override
+  Future<String?> getApplicationLabel({required String packageName}) =>
+      _channel.invokeMethod<String>(
+        "getApplicationLabel",
+        {
+          "packageName": packageName,
+        },
+      );
 
   @override
   Future<Uint8List?> getActivityIcon({
     required String packageName,
     BitmapCompressFormat format = BitmapCompressFormat.png,
     int quality = 100,
-  }) => _channel.invokeMethod<Uint8List>(
-    "getActivityIcon",
-    {
-      'packageName': packageName,
-      'quality': quality.clamp(1, 100,),
-      'format': format.index,
-    },
-  );
+  }) =>
+      _channel.invokeMethod<Uint8List>(
+        "getActivityIcon",
+        {
+          'packageName': packageName,
+          'quality': quality.clamp(
+            1,
+            100,
+          ),
+          'format': format.index,
+        },
+      );
 
   @override
   Future<Uint8List?> getActivityLogo({
     required String packageName,
     BitmapCompressFormat format = BitmapCompressFormat.png,
     int quality = 100,
-  }) => _channel.invokeMethod<Uint8List>(
-    "getActivityLogo",
-    {
-      'packageName': packageName,
-      'quality': quality.clamp(1, 100,),
-      'format': format.index,
-    },
-  );
+  }) =>
+      _channel.invokeMethod<Uint8List>(
+        "getActivityLogo",
+        {
+          'packageName': packageName,
+          'quality': quality.clamp(
+            1,
+            100,
+          ),
+          'format': format.index,
+        },
+      );
 
   @override
-  Future<bool?> getComponentEnabledSetting({required String packageName,}) => _channel.invokeMethod<bool>(
-    "getComponentEnabledSetting",
-    {"packageName": packageName,},
-  );
+  Future<bool?> getComponentEnabledSetting({
+    required String packageName,
+  }) =>
+      _channel.invokeMethod<bool>(
+        "getComponentEnabledSetting",
+        {
+          "packageName": packageName,
+        },
+      );
 
   @override
-  Future<Uint8List?> getDefaultActivityIcon() => _channel.invokeMethod<Uint8List>(
-    "getDefaultActivityIcon",
-  );
+  Future<Uint8List?> getDefaultActivityIcon() =>
+      _channel.invokeMethod<Uint8List>(
+        "getDefaultActivityIcon",
+      );
 
   @override
   Future<List<ApplicationInfo>?> getInstalledApplications({
@@ -165,13 +225,21 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final installedApplicationsData = await _channel.invokeListMethod(
       "getInstalledApplications",
-      {"flags": flags?.flags,},
+      {
+        "flags": flags?.flags,
+      },
     );
-    return installedApplicationsData?.map<ApplicationInfo>(
-      (data) => ApplicationInfoImpl(
-        Map<String, dynamic>.from(data,),
-      ),
-    ).toList(growable: false,);
+    return installedApplicationsData
+        ?.map<ApplicationInfo>(
+          (data) => ApplicationInfoImpl(
+            Map<String, dynamic>.from(
+              data,
+            ),
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
@@ -180,11 +248,15 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final sourceInfo = await _channel.invokeMapMethod(
       'getInstallSourceInfo',
-      {'packageName': packageName,},
+      {
+        'packageName': packageName,
+      },
     );
     if (sourceInfo != null) {
       return InstallSourceInfoImpl(
-        Map<String, dynamic>.from(sourceInfo,),
+        Map<String, dynamic>.from(
+          sourceInfo,
+        ),
       );
     }
     return null;
@@ -196,20 +268,30 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final installedPackagesData = await _channel.invokeListMethod(
       "getInstalledPackages",
-      {"flags": flags?.flags,},
+      {
+        "flags": flags?.flags,
+      },
     );
-    return installedPackagesData?.map<PackageInfo>(
-      (data) => PackageInfoImpl(
-        Map<String, dynamic>.from(data,),
-      ),
-    ).toList(growable: false,);
+    return installedPackagesData
+        ?.map<PackageInfo>(
+          (data) => PackageInfoImpl(
+            Map<String, dynamic>.from(
+              data,
+            ),
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
   Future<String?> getInstallerPackageName({required String packageName}) async {
     final installerPackageName = await _channel.invokeMethod(
       'getInstallerPackageName',
-      {'packageName': packageName,},
+      {
+        'packageName': packageName,
+      },
     );
     return installerPackageName?.toString();
   }
@@ -234,12 +316,16 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
 
   @override
   Future<String?> getNameForUid(int uid) => _channel.invokeMethod<String>(
-    "getNameForUid", {'uid': uid,},
-  );
+        "getNameForUid",
+        {
+          'uid': uid,
+        },
+      );
 
   @override
   Future<PackageInfo?> getPackageArchiveInfo({
-    required String archiveFilePath, PackageInfoFlags? flags,
+    required String archiveFilePath,
+    PackageInfoFlags? flags,
   }) async {
     final packageData = await _channel.invokeMethod(
       "getPackageArchiveInfo",
@@ -250,7 +336,9 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
     );
     if (packageData != null) {
       return PackageInfoImpl(
-        Map<String, dynamic>.from(packageData,),
+        Map<String, dynamic>.from(
+          packageData,
+        ),
       );
     }
     return null;
@@ -260,9 +348,13 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   Future<List<int>?> getPackageGids({required String packageName}) async {
     final data = await _channel.invokeListMethod(
       "getPackageGids",
-      {"packageName": packageName,},
+      {
+        "packageName": packageName,
+      },
     );
-    return data?.whereType<int>().toList(growable: false,);
+    return data?.whereType<int>().toList(
+          growable: false,
+        );
   }
 
   @override
@@ -272,11 +364,16 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final packageData = await _channel.invokeMethod(
       "getPackageInfo",
-      {"packageName": packageName, "flags": flags?.flags,},
+      {
+        "packageName": packageName,
+        "flags": flags?.flags,
+      },
     );
     if (packageData != null) {
       return PackageInfoImpl(
-        Map<String, dynamic>.from(packageData,),
+        Map<String, dynamic>.from(
+          packageData,
+        ),
       );
     }
     return null;
@@ -284,31 +381,50 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
 
   @override
   Future<List<String>?> getPackagesForUid(int uid) async {
-    final data = await _channel.invokeListMethod(
-      "getPackagesForUid", {"uid": uid,}
-    );
-    return data?.whereType<String>().toList(growable: false,);
+    final data = await _channel.invokeListMethod("getPackagesForUid", {
+      "uid": uid,
+    });
+    return data?.whereType<String>().toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<List<PackageInfo>?> getPackagesHoldingPermissions(Set<String> permissions) async {
+  Future<List<PackageInfo>?> getPackagesHoldingPermissions(
+      Set<String> permissions) async {
     final packagesData = await _channel.invokeListMethod(
       "getPackagesHoldingPermissions",
-      {"permissions": permissions.toList(),},
+      {
+        "permissions": permissions.toList(),
+      },
     );
-    return packagesData?.whereType<Map<String, dynamic>>().map(
-      (e) => PackageInfoImpl(e,),
-    ).toList(growable: false,);
+    return packagesData
+        ?.whereType<Map<String, dynamic>>()
+        .map(
+          (e) => PackageInfoImpl(
+            e,
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<PermissionGroupInfo?> getPermissionGroupInfo(String packageName,) async {
+  Future<PermissionGroupInfo?> getPermissionGroupInfo(
+    String packageName,
+  ) async {
     final infoData = await _channel.invokeMethod(
-      "getPermissionGroupInfo", {"packageName": packageName,},
+      "getPermissionGroupInfo",
+      {
+        "packageName": packageName,
+      },
     );
     if (infoData != null) {
       return PermissionGroupInfoImpl(
-        Map<String, dynamic>.from(infoData,),
+        Map<String, dynamic>.from(
+          infoData,
+        ),
       );
     }
     return null;
@@ -317,11 +433,16 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   @override
   Future<PermissionInfo?> getPermissionInfo(String permName) async {
     final infoData = await _channel.invokeMethod(
-      "getPermissionInfo", {"permName": permName,},
+      "getPermissionInfo",
+      {
+        "permName": permName,
+      },
     );
     if (infoData != null) {
       return PermissionInfoImpl(
-        Map<String, dynamic>.from(infoData,),
+        Map<String, dynamic>.from(
+          infoData,
+        ),
       );
     }
     return null;
@@ -334,25 +455,36 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final providerData = await _channel.invokeMethod(
       "getProviderInfo",
-      {...componentName.asMap, "flags": flags?.flags,},
+      {
+        ...componentName.asMap,
+        "flags": flags?.flags,
+      },
     );
     if (providerData != null) {
       return ProviderInfoImpl(
-        Map<String, dynamic>.from(providerData,),
+        Map<String, dynamic>.from(
+          providerData,
+        ),
       );
     }
     return null;
   }
 
   @override
-  Future<ActivityInfo?> getReceiverInfo({required ComponentName componentName, ComponentInfoFlags? flags}) async {
+  Future<ActivityInfo?> getReceiverInfo(
+      {required ComponentName componentName, ComponentInfoFlags? flags}) async {
     final receiverData = await _channel.invokeMethod(
       "getReceiverInfo",
-      {...componentName.asMap, "flags": flags?.flags,},
+      {
+        ...componentName.asMap,
+        "flags": flags?.flags,
+      },
     );
     if (receiverData != null) {
       return ActivityInfoImpl(
-        Map<String, dynamic>.from(receiverData,),
+        Map<String, dynamic>.from(
+          receiverData,
+        ),
       );
     }
     return null;
@@ -360,15 +492,21 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
 
   @override
   Future<ServiceInfo?> getServiceInfo({
-    required ComponentName componentName, ComponentInfoFlags? flags,
+    required ComponentName componentName,
+    ComponentInfoFlags? flags,
   }) async {
     final serviceData = await _channel.invokeMethod(
       "getServiceInfo",
-      {...componentName.asMap, "flags": flags?.flags,},
+      {
+        ...componentName.asMap,
+        "flags": flags?.flags,
+      },
     );
     if (serviceData != null) {
       return ServiceInfoImpl(
-        Map<String, dynamic>.from(serviceData,),
+        Map<String, dynamic>.from(
+          serviceData,
+        ),
       );
     }
     return null;
@@ -379,9 +517,16 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
     final featureData = await _channel.invokeListMethod(
       "getSystemAvailableFeatures",
     );
-    return featureData?.whereType<Map<String, dynamic>>().map(
-      (e) => FeatureInfoImpl(e,),
-    ).toList(growable: false,);
+    return featureData
+        ?.whereType<Map<String, dynamic>>()
+        .map(
+          (e) => FeatureInfoImpl(
+            e,
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
@@ -389,31 +534,49 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
     final nameData = await _channel.invokeListMethod(
       "getSystemSharedLibraryNames",
     );
-    return nameData?.whereType<String>().toList(growable: false,);
+    return nameData?.whereType<String>().toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<bool> hasSystemFeature({required String featureName, int? version}) => _channel.invokeMethod(
-    "hasSystemFeature",
-    {"featureName": featureName, "version": version,},
-  ).then((result) => result == true,);
+  Future<bool> hasSystemFeature({required String featureName, int? version}) =>
+      _channel.invokeMethod(
+        "hasSystemFeature",
+        {
+          "featureName": featureName,
+          "version": version,
+        },
+      ).then(
+        (result) => result == true,
+      );
 
   @override
-  Future<bool> isSafeMode() => _channel.invokeMethod("isSafeMode",).then(
-    (result) => result == true,
-  );
+  Future<bool> isSafeMode() => _channel
+      .invokeMethod(
+        "isSafeMode",
+      )
+      .then(
+        (result) => result == true,
+      );
 
   @override
   Future<void> launchLeanback(String packageName) async {
     await _channel.invokeMethod(
-      "launchLeanback", {"packageName": packageName,},
+      "launchLeanback",
+      {
+        "packageName": packageName,
+      },
     );
   }
 
   @override
   Future<void> openApp(String packageName) async {
     await _channel.invokeMethod(
-      "openApp", {"packageName": packageName,},
+      "openApp",
+      {
+        "packageName": packageName,
+      },
     );
   }
 
@@ -425,47 +588,88 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
   }) async {
     final providerData = await _channel.invokeListMethod(
       "queryContentProviders",
-      {"uid": uid, "processName": processName, "flags": flags?.flags,},
+      {
+        "uid": uid,
+        "processName": processName,
+        "flags": flags?.flags,
+      },
     );
-    return providerData?.whereType<Map<String, dynamic>>().map(
-      (e) => ProviderInfoImpl(e,),
-    ).toList(growable: false,);
+    return providerData
+        ?.whereType<Map<String, dynamic>>()
+        .map(
+          (e) => ProviderInfoImpl(
+            e,
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<List<InstrumentationInfo>?> queryInstrumentation(String targetPackage,) async {
-    final info = await _channel.invokeListMethod("queryInstrumentation",);
-    return info?.whereType<Map<String, dynamic>>().map(
-      (e) => InstrumentationInfoImpl(e,),
-    ).toList(growable: false,);
+  Future<List<InstrumentationInfo>?> queryInstrumentation(
+    String targetPackage,
+  ) async {
+    final info = await _channel.invokeListMethod(
+      "queryInstrumentation",
+    );
+    return info
+        ?.whereType<Map<String, dynamic>>()
+        .map(
+          (e) => InstrumentationInfoImpl(
+            e,
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
-  Future<List<PermissionInfo>?> queryPermissionsByGroup(String permissionGroup) async {
-    final info = await _channel.invokeListMethod("queryPermissionsByGroup",);
-    return info?.whereType<Map<String, dynamic>>().map(
-      (e) => PermissionInfoImpl(e,),
-    ).toList(growable: false,);
+  Future<List<PermissionInfo>?> queryPermissionsByGroup(
+      String permissionGroup) async {
+    final info = await _channel.invokeListMethod(
+      "queryPermissionsByGroup",
+    );
+    return info
+        ?.whereType<Map<String, dynamic>>()
+        .map(
+          (e) => PermissionInfoImpl(
+            e,
+          ),
+        )
+        .toList(
+          growable: false,
+        );
   }
 
   @override
   Future<void> removePermission(String permName) async {
     await _channel.invokeMethod(
-      "removePermission", {"permName": permName,},
+      "removePermission",
+      {
+        "permName": permName,
+      },
     );
   }
 
   @override
   Future<ProviderInfo?> resolveContentProvider({
-    required String authority, ComponentInfoFlags? flags,
+    required String authority,
+    ComponentInfoFlags? flags,
   }) async {
     final providerData = await _channel.invokeMethod(
       "resolveContentProvider",
-      {"authority": authority, "flags": flags?.flags,},
+      {
+        "authority": authority,
+        "flags": flags?.flags,
+      },
     );
     if (providerData != null) {
       return ProviderInfoImpl(
-        Map<String, dynamic>.from(providerData,),
+        Map<String, dynamic>.from(
+          providerData,
+        ),
       );
     }
     return null;
@@ -519,7 +723,8 @@ class AndroidPackageManagerImpl extends AndroidPackageManager {
 
   @override
   Future<void> verifyPendingInstall({
-    required int id, required VerificationCode verificationCode,
+    required int id,
+    required VerificationCode verificationCode,
   }) async {
     await _channel.invokeMethod(
       "verifyPendingInstall",

--- a/lib/src/entities/base/package_info.dart
+++ b/lib/src/entities/base/package_info.dart
@@ -10,30 +10,29 @@ import 'provider_info.dart';
 import 'service_info.dart';
 
 abstract class PackageInfo {
-
-  const PackageInfo({
-    this.activities,
-    this.applicationInfo,
-    this.configPreferences,
-    this.featureGroups,
-    this.firstInstallTime,
-    this.gids,
-    required this.installLocation,
-    this.instrumentation,
-    this.lastUpdateTime,
-    this.packageName,
-    this.permissions,
-    this.providers,
-    this.receivers,
-    this.reqFeatures,
-    this.requestedPermissions,
-    this.requestedPermissionFlags,
-    this.services,
-    this.sharedUserId,
-    this.sharedUserLabel,
-    this.splitNames,
-    this.versionName,
-  });
+  const PackageInfo(
+      {this.activities,
+      this.applicationInfo,
+      this.configPreferences,
+      this.featureGroups,
+      this.firstInstallTime,
+      this.gids,
+      required this.installLocation,
+      this.instrumentation,
+      this.lastUpdateTime,
+      this.packageName,
+      this.permissions,
+      this.providers,
+      this.receivers,
+      this.reqFeatures,
+      this.requestedPermissions,
+      this.requestedPermissionFlags,
+      this.services,
+      this.sharedUserId,
+      this.sharedUserLabel,
+      this.splitNames,
+      this.versionName,
+      this.versionCode});
 
   final List<ActivityInfo>? activities;
   final ApplicationInfo? applicationInfo;
@@ -56,4 +55,5 @@ abstract class PackageInfo {
   final int? sharedUserLabel;
   final List<String>? splitNames;
   final String? versionName;
+  final int? versionCode;
 }

--- a/lib/src/entities/base/package_item_info.dart
+++ b/lib/src/entities/base/package_item_info.dart
@@ -3,20 +3,26 @@ import 'dart:typed_data';
 import 'package:android_package_manager/android_package_manager.dart';
 
 class PackageItemInfo {
-
-  PackageItemInfo(Map<String, dynamic> data,)
-      : name = data['name'],
+  PackageItemInfo(
+    Map<String, dynamic> data,
+  )   : name = data['name'],
         packageName = data['packageName'],
         labelRes = data['labelRes'],
         nonLocalizedLabel = data['nonLocalizedLabel'],
         icon = data['icon'],
         banner = data['banner'],
         logo = data['logo'],
-        metaData = _parseMetaData(data['metaData'],);
+        metaData = _parseMetaData(
+          data['metaData'],
+        );
 
-  static Map<String, dynamic>? _parseMetaData(dynamic data,) {
+  static Map<String, dynamic>? _parseMetaData(
+    dynamic data,
+  ) {
     if (data is Map) {
-      return Map<String, dynamic>.from(data,);
+      return Map<String, dynamic>.from(
+        data,
+      );
     }
     return null;
   }
@@ -31,6 +37,14 @@ class PackageItemInfo {
         format: format,
         quality: quality,
       );
+    }
+    return null;
+  }
+
+  Future<String?> getAppLabel() async {
+    if (packageName != null) {
+      return AndroidPackageManager()
+          .getApplicationLabel(packageName: packageName!);
     }
     return null;
   }

--- a/lib/src/entities/impl/package_info.dart
+++ b/lib/src/entities/impl/package_info.dart
@@ -20,54 +20,95 @@ import 'provider_info.dart';
 import 'service_info.dart';
 
 class PackageInfoImpl extends PackageInfo {
-  
-  PackageInfoImpl(Map<String, dynamic> data,) : super(
-    activities: safeListParse<ActivityInfo>(
-      data['activities'], (data) => ActivityInfoImpl(data,),
-    ),
-    applicationInfo: safeMapParse<ApplicationInfo>(
-      data['applicationInfo'], (data) => ApplicationInfoImpl(data,),
-    ),
-    configPreferences: safeListParse<ConfigurationInfo>(
-      data['configPreferences'], (data) => ConfigurationInfoImpl(data,),
-    ),
-    featureGroups: safeListParse<FeatureGroupInfo>(
-      data['featureGroups'], (data) => FeatureGroupInfoImpl(data,),
-    ),
-    firstInstallTime: data['firstInstallTime'],
-    gids: data['gids'],
-    installLocation: _parseInstallLocation(data['installLocation'],),
-    instrumentation: safeListParse<InstrumentationInfo>(
-      data['instrumentation'], (data) => InstrumentationInfoImpl(data,),
-    ),
-    lastUpdateTime: data['lastUpdateTime'],
-    packageName: data['packageName'],
-    permissions: safeListParse<PermissionInfo>(
-      data['permissions'], (data) => PermissionInfoImpl(data,),
-    ),
-    providers: safeListParse<ProviderInfo>(
-      data['providers'], (data) => ProviderInfoImpl(data,),
-    ),
-    receivers: safeListParse<ActivityInfo>(
-      data['receivers'], (data) => ActivityInfoImpl(data,),
-    ),
-    reqFeatures: safeListParse<FeatureInfo>(
-      data['reqFeatures'], (data) => FeatureInfoImpl(data,),
-    ),
-    requestedPermissions: asTypedList<String>(data['requestedPermissions'],),
-    requestedPermissionFlags: data['requestedPermissionFlags'],
-    services: safeListParse<ServiceInfo>(
-      data['services'], (data) => ServiceInfoImpl(data,),
-    ),
-    sharedUserId: data['sharedUserId'],
-    sharedUserLabel: data['sharedUserLabel'],
-    splitNames: data['splitNames']?.whereType<String>().toList(growable: false,),
-    versionName: data['versionName'],
-  );
+  PackageInfoImpl(
+    Map<String, dynamic> data,
+  ) : super(
+          activities: safeListParse<ActivityInfo>(
+            data['activities'],
+            (data) => ActivityInfoImpl(
+              data,
+            ),
+          ),
+          applicationInfo: safeMapParse<ApplicationInfo>(
+            data['applicationInfo'],
+            (data) => ApplicationInfoImpl(
+              data,
+            ),
+          ),
+          configPreferences: safeListParse<ConfigurationInfo>(
+            data['configPreferences'],
+            (data) => ConfigurationInfoImpl(
+              data,
+            ),
+          ),
+          featureGroups: safeListParse<FeatureGroupInfo>(
+            data['featureGroups'],
+            (data) => FeatureGroupInfoImpl(
+              data,
+            ),
+          ),
+          firstInstallTime: data['firstInstallTime'],
+          gids: data['gids'],
+          installLocation: _parseInstallLocation(
+            data['installLocation'],
+          ),
+          instrumentation: safeListParse<InstrumentationInfo>(
+            data['instrumentation'],
+            (data) => InstrumentationInfoImpl(
+              data,
+            ),
+          ),
+          lastUpdateTime: data['lastUpdateTime'],
+          packageName: data['packageName'],
+          permissions: safeListParse<PermissionInfo>(
+            data['permissions'],
+            (data) => PermissionInfoImpl(
+              data,
+            ),
+          ),
+          providers: safeListParse<ProviderInfo>(
+            data['providers'],
+            (data) => ProviderInfoImpl(
+              data,
+            ),
+          ),
+          receivers: safeListParse<ActivityInfo>(
+            data['receivers'],
+            (data) => ActivityInfoImpl(
+              data,
+            ),
+          ),
+          reqFeatures: safeListParse<FeatureInfo>(
+            data['reqFeatures'],
+            (data) => FeatureInfoImpl(
+              data,
+            ),
+          ),
+          requestedPermissions: asTypedList<String>(
+            data['requestedPermissions'],
+          ),
+          requestedPermissionFlags: data['requestedPermissionFlags'],
+          services: safeListParse<ServiceInfo>(
+            data['services'],
+            (data) => ServiceInfoImpl(
+              data,
+            ),
+          ),
+          sharedUserId: data['sharedUserId'],
+          sharedUserLabel: data['sharedUserLabel'],
+          splitNames: data['splitNames']?.whereType<String>().toList(
+                growable: false,
+              ),
+          versionName: data['versionName'],
+          versionCode: data['versionCode'],
+        );
 
-  static AndroidInstallLocation _parseInstallLocation(dynamic data,) {
+  static AndroidInstallLocation _parseInstallLocation(
+    dynamic data,
+  ) {
     if (data is int) {
-      AndroidInstallLocation.values.asMap()[data + 1] ?? AndroidInstallLocation.unspecified;
+      AndroidInstallLocation.values.asMap()[data + 1] ??
+          AndroidInstallLocation.unspecified;
     }
     return AndroidInstallLocation.unspecified;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.5.4
 homepage: https://github.com/nsNeruno/android_package_manager
 
 environment:
-  sdk: ">=2.19.3 <=3.0.0"
+  sdk: ">=2.19.3 <=4.0.0"
   flutter: ">=2.5.0"
 
 dependencies:


### PR DESCRIPTION
Allow Some Functionality in Background Isolates:
- The plugin currently does not work at all in background isolates (such as those created by the [android_alarm_manager_plus](https://pub.dev/packages/android_alarm_manager_plus) plugin).
- This is because the Android `PackageManager` is taken from the `binding.activity` object, which is never defined in background isolates.
- However, the `flutterPluginBinding.applicationContext` is still available, and does provide a `PackageManager` as well which we can use.
- This PR adds code to grab the `PackageManager` from `flutterPluginBinding.applicationContext` first (when the app is registered), before it is replaced by `binding.activity.PackageManager` later on if possible.
- I don't know what the downsides are (if any) of using the `Context.PackageManager` instead of `Activity.PackageManager`, but it does seem to work for all usages I tried (listing installed apps, getting the installer info for a given app, etc.); in any case, this change is only relevant in background isolates where the plugin didn't work at all before.

Other changes:
- SDK target for the plugin changed to `">=2.19.3 <=4.0.0"` because the latest version of Flutter uses Dart SDK `3.0.6`. As of right now, anyone who is on the Flutter stable can only use version `0.5.0` of this plugin.
- Adds the `versionCode` variable to `PackageInfo` (the newer [`getLongVersionCode()`](https://developer.android.com/reference/android/content/pm/PackageInfo#versionCode) is still missing).
- Adds the `getApplicationLabel` function.
